### PR TITLE
`enhancement` Use ThreadPoolExecutor for all threaded jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ VOSK_MODEL_DIR=/data
 VOSK_DWNLD_URLS=https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip,https://alphacephei.com/vosk/models/vosk-model-small-de-0.15.zip
 VOSK_MODELS=model-fr:fr,model-en:en
 WHISPER_MODEL=medium
+MAX_WORKERS=10
 ```
 </p>
 </details>
@@ -114,6 +115,7 @@ vosk:
       lang: 'de'
 whisper:
   model: 'tiny'
+max_workers: 10
 ```
 </p>
 </details>

--- a/config.yml
+++ b/config.yml
@@ -16,3 +16,4 @@ vosk:
       lang: 'de'
 whisper:
   model: 'tiny'
+max_workers: 12

--- a/protobufs/subtitles.proto
+++ b/protobufs/subtitles.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
 package live.voice.v1;
 
+import "google/protobuf/empty.proto";
+
 // Implemented in voice-service
 service SubtitleGenerator {
-  rpc Generate (GenerateRequest) returns (Empty) {}
+  rpc Generate (GenerateRequest) returns (google.protobuf.Empty) {}
 }
 
 // Implemented in tum-live
 service SubtitleReceiver {
-  rpc Receive (ReceiveRequest) returns (Empty) {}
+  rpc Receive (ReceiveRequest) returns (google.protobuf.Empty) {}
 }
 
 message ReceiveRequest {
@@ -22,5 +24,3 @@ message GenerateRequest {
   string source_file = 2;
   string language = 3;
 }
-
-message Empty {}

--- a/subtitles/model_loader.py
+++ b/subtitles/model_loader.py
@@ -15,7 +15,7 @@ def download_models(model_dir: str, download_urls: [str]) -> None:
         download_urls ([str]): URLs pointing to VOSK Language Models.
     """
     try:
-        os.mkdir(os.path.join(model_dir, '.lock'))
+        os.makedirs(os.path.join(model_dir, '.lock'), exist_ok=True)
     except FileExistsError:
         return  # already downloaded or initiated
 

--- a/subtitles/properties.py
+++ b/subtitles/properties.py
@@ -77,7 +77,9 @@ class EnvProperties:
 
         properties['whisper']['model'] = os.getenv('WHISPER_MODEL', properties['whisper']['model'])
 
-        properties['max_workers'] = int(os.getenv('MAX_WORKERS', properties['max_workers']))
+        max_workers = os.getenv('MAX_WORKERS', properties['max_workers'])
+        if max_workers:
+            properties['max_workers'] = int(max_workers)
 
         return properties
 

--- a/subtitles/properties.py
+++ b/subtitles/properties.py
@@ -77,6 +77,8 @@ class EnvProperties:
 
         properties['whisper']['model'] = os.getenv('WHISPER_MODEL', properties['whisper']['model'])
 
+        properties['max_workers'] = int(os.getenv('MAX_WORKERS', properties['max_workers']))
+
         return properties
 
     def __to_model_obj(self, model: str):

--- a/subtitles/subtitles.py
+++ b/subtitles/subtitles.py
@@ -11,7 +11,7 @@ from model_loader import download_models, ModelLoadError
 import grpc
 import subtitles_pb2
 import subtitles_pb2_grpc
-from vosk_transcriber import VoskTranscriber
+from vosk_transcriber import VoskTranscriber, set_vosk_log_level
 from whisper_transcriber import WhisperTranscriber
 from transcriber import Transcriber
 
@@ -56,7 +56,7 @@ class SubtitleServerService(subtitles_pb2_grpc.SubtitleGeneratorServicer):
         self.__executor.submit(self.__generate, self.__transcriber, source, stream_id, language)
         return empty_pb2.Empty()
 
-    def __generate(self, transcriber: VoskTranscriber, source: str, stream_id: str, language: str) -> None:
+    def __generate(self, transcriber: Transcriber, source: str, stream_id: str, language: str) -> None:
         subtitles, language = transcriber.generate(source, language)
 
         logging.info(f'trying to connect to receiver @ {self.__receiver}')
@@ -137,6 +137,7 @@ def activate_reflection(server: grpc.Server) -> None:
 def main():
     debug = os.getenv('DEBUG', '') != ""
     logging.basicConfig(level=(logging.INFO, logging.DEBUG)[debug])
+    set_vosk_log_level(debug)
 
     properties = {
         'api': {'port': 50055},

--- a/subtitles/subtitles.py
+++ b/subtitles/subtitles.py
@@ -76,16 +76,18 @@ class SubtitleServerService(subtitles_pb2_grpc.SubtitleGeneratorServicer):
                 logging.error(err)
 
 
-def serve(properties: dict, debug: bool = False) -> None:
+def serve(transcriber: Transcriber,
+          receiver: str,
+          port: int,
+          debug: bool = False) -> None:
     """Starts the grpc server.
 
     Args:
-        properties: The configuration of the server.
+        transcriber: The transcriber used.
+        receiver: The network address of the receiver.
+        port: The port on which the voice service listens.
         debug: Whether the server should be started in debug mode or not.
     """
-    transcriber = get_transcriber(properties, debug)
-    receiver = f'{properties["receiver"]["host"]}:{properties["receiver"]["port"]}'
-    port = properties['api']['port']
 
     with ThreadPoolExecutor(max_workers=None) as executor:
         server = grpc.server(executor)
@@ -94,7 +96,6 @@ def serve(properties: dict, debug: bool = False) -> None:
             server=server)
 
         if debug:
-            logging.debug(properties)
             activate_reflection(server)
 
         logging.info(f'listening at :{port}')
@@ -170,7 +171,12 @@ def main():
         logging.error(modelLoadErr)
         sys.exit(3)
 
-    serve(properties, debug)
+    transcriber = get_transcriber(properties, debug)
+    receiver = f'{properties["receiver"]["host"]}:{properties["receiver"]["port"]}'
+    port = properties['api']['port']
+
+    logging.debug(properties)
+    serve(transcriber, receiver, port, debug)
 
 
 if __name__ == "__main__":

--- a/subtitles/subtitles.py
+++ b/subtitles/subtitles.py
@@ -2,17 +2,11 @@ import sys
 import logging
 import os
 from signal import signal, SIGTERM, SIGINT, SIGQUIT, strsignal
-
 from concurrent.futures import ThreadPoolExecutor
-
-import google
-
 from properties import YAMLPropertiesFile, EnvProperties, PropertyError
 from grpc_reflection.v1alpha import reflection
 from grpc._channel import _InactiveRpcError
-
 from google.protobuf import empty_pb2
-
 from model_loader import download_models, ModelLoadError
 import grpc
 import subtitles_pb2
@@ -93,7 +87,7 @@ def serve(properties: dict, debug: bool = False) -> None:
     receiver = f'{properties["receiver"]["host"]}:{properties["receiver"]["port"]}'
     port = properties['api']['port']
 
-    with ThreadPoolExecutor(max_workers=10) as executor:  # TODO: How to determine how many workers? Guess?
+    with ThreadPoolExecutor(max_workers=None) as executor:
         server = grpc.server(executor)
         subtitles_pb2_grpc.add_SubtitleGeneratorServicer_to_server(
             servicer=SubtitleServerService(transcriber, receiver, executor),

--- a/subtitles/subtitles_pb2.py
+++ b/subtitles/subtitles_pb2.py
@@ -11,23 +11,22 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0fsubtitles.proto\x12\rlive.voice.v1\"H\n\x0eReceiveRequest\x12\x11\n\tstream_id\x18\x01 \x01(\x05\x12\x11\n\tsubtitles\x18\x02 \x01(\t\x12\x10\n\x08language\x18\x03 \x01(\t\"K\n\x0fGenerateRequest\x12\x11\n\tstream_id\x18\x01 \x01(\x05\x12\x13\n\x0bsource_file\x18\x02 \x01(\t\x12\x10\n\x08language\x18\x03 \x01(\t\"\x07\n\x05\x45mpty2W\n\x11SubtitleGenerator\x12\x42\n\x08Generate\x12\x1e.live.voice.v1.GenerateRequest\x1a\x14.live.voice.v1.Empty\"\x00\x32T\n\x10SubtitleReceiver\x12@\n\x07Receive\x12\x1d.live.voice.v1.ReceiveRequest\x1a\x14.live.voice.v1.Empty\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0fsubtitles.proto\x12\rlive.voice.v1\x1a\x1bgoogle/protobuf/empty.proto\"H\n\x0eReceiveRequest\x12\x11\n\tstream_id\x18\x01 \x01(\x05\x12\x11\n\tsubtitles\x18\x02 \x01(\t\x12\x10\n\x08language\x18\x03 \x01(\t\"K\n\x0fGenerateRequest\x12\x11\n\tstream_id\x18\x01 \x01(\x05\x12\x13\n\x0bsource_file\x18\x02 \x01(\t\x12\x10\n\x08language\x18\x03 \x01(\t2Y\n\x11SubtitleGenerator\x12\x44\n\x08Generate\x12\x1e.live.voice.v1.GenerateRequest\x1a\x16.google.protobuf.Empty\"\x00\x32V\n\x10SubtitleReceiver\x12\x42\n\x07Receive\x12\x1d.live.voice.v1.ReceiveRequest\x1a\x16.google.protobuf.Empty\"\x00\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'subtitles_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _RECEIVEREQUEST._serialized_start=34
-  _RECEIVEREQUEST._serialized_end=106
-  _GENERATEREQUEST._serialized_start=108
-  _GENERATEREQUEST._serialized_end=183
-  _EMPTY._serialized_start=185
-  _EMPTY._serialized_end=192
-  _SUBTITLEGENERATOR._serialized_start=194
-  _SUBTITLEGENERATOR._serialized_end=281
-  _SUBTITLERECEIVER._serialized_start=283
-  _SUBTITLERECEIVER._serialized_end=367
+  _RECEIVEREQUEST._serialized_start=63
+  _RECEIVEREQUEST._serialized_end=135
+  _GENERATEREQUEST._serialized_start=137
+  _GENERATEREQUEST._serialized_end=212
+  _SUBTITLEGENERATOR._serialized_start=214
+  _SUBTITLEGENERATOR._serialized_end=303
+  _SUBTITLERECEIVER._serialized_start=305
+  _SUBTITLERECEIVER._serialized_end=391
 # @@protoc_insertion_point(module_scope)

--- a/subtitles/subtitles_pb2_grpc.py
+++ b/subtitles/subtitles_pb2_grpc.py
@@ -2,6 +2,7 @@
 """Client and server classes corresponding to protobuf-defined services."""
 import grpc
 
+from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 import subtitles_pb2 as subtitles__pb2
 
 
@@ -18,7 +19,7 @@ class SubtitleGeneratorStub(object):
         self.Generate = channel.unary_unary(
                 '/live.voice.v1.SubtitleGenerator/Generate',
                 request_serializer=subtitles__pb2.GenerateRequest.SerializeToString,
-                response_deserializer=subtitles__pb2.Empty.FromString,
+                response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
                 )
 
 
@@ -38,7 +39,7 @@ def add_SubtitleGeneratorServicer_to_server(servicer, server):
             'Generate': grpc.unary_unary_rpc_method_handler(
                     servicer.Generate,
                     request_deserializer=subtitles__pb2.GenerateRequest.FromString,
-                    response_serializer=subtitles__pb2.Empty.SerializeToString,
+                    response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -64,7 +65,7 @@ class SubtitleGenerator(object):
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/live.voice.v1.SubtitleGenerator/Generate',
             subtitles__pb2.GenerateRequest.SerializeToString,
-            subtitles__pb2.Empty.FromString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -82,7 +83,7 @@ class SubtitleReceiverStub(object):
         self.Receive = channel.unary_unary(
                 '/live.voice.v1.SubtitleReceiver/Receive',
                 request_serializer=subtitles__pb2.ReceiveRequest.SerializeToString,
-                response_deserializer=subtitles__pb2.Empty.FromString,
+                response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
                 )
 
 
@@ -102,7 +103,7 @@ def add_SubtitleReceiverServicer_to_server(servicer, server):
             'Receive': grpc.unary_unary_rpc_method_handler(
                     servicer.Receive,
                     request_deserializer=subtitles__pb2.ReceiveRequest.FromString,
-                    response_serializer=subtitles__pb2.Empty.SerializeToString,
+                    response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -128,6 +129,6 @@ class SubtitleReceiver(object):
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/live.voice.v1.SubtitleReceiver/Receive',
             subtitles__pb2.ReceiveRequest.SerializeToString,
-            subtitles__pb2.Empty.FromString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/subtitles/vosk_transcriber.py
+++ b/subtitles/vosk_transcriber.py
@@ -1,11 +1,7 @@
 import subprocess
-
 import vosk
 from vosk import Model, KaldiRecognizer, SetLogLevel
 from transcriber import Transcriber
-from threading import Lock
-
-mutex_vosk = Lock()
 
 
 class VoskTranscriptionError(Exception):
@@ -23,9 +19,7 @@ class VoskTranscriber(Transcriber):
                 Visit https://alphacephei.com/vosk/models for a list of available models.
         """
         super().__init__()
-        self.__recognizers = {
-            model['lang']: new_recognizer(model['path'])
-            for model in models}
+        self.__models = {model['lang']: model['path'] for model in models}
 
     def generate(self, source: str, language: str) -> (str, str):
         with subprocess.Popen(['ffmpeg',
@@ -35,12 +29,9 @@ class VoskTranscriber(Transcriber):
                                '-ac', '1',
                                '-f', 'wav', "-"],
                               stdout=subprocess.PIPE).stdout as stream:
-            if language in self.__recognizers:
-                mutex_vosk.acquire()
-                try:
-                    return self.__recognizers[language].SrtResult(stream), language
-                finally:
-                    mutex_vosk.release()
+            if language in self.__models:
+                recognizer = new_recognizer(self.__models[language])
+                return recognizer.SrtResult(stream), language
 
             else:
                 raise VoskTranscriptionError(f'Unsupported language: {language}')

--- a/subtitles/vosk_transcriber.py
+++ b/subtitles/vosk_transcriber.py
@@ -11,15 +11,20 @@ class VoskTranscriptionError(Exception):
 class VoskTranscriber(Transcriber):
     SAMPLE_RATE = 16000
 
-    def __init__(self, models: [object]) -> None:
+    def __init__(self, models: [object], debug: bool) -> None:
         """Initialize VoskTranscriber with an array of given models.
 
         Args:
             models: Array of (language, model) tuples
                 Visit https://alphacephei.com/vosk/models for a list of available models.
+            debug: Display debug information or not.
         """
         super().__init__()
+
         self.__models = {model['lang']: model['path'] for model in models}
+
+        if not debug:
+            SetLogLevel(-1)
 
     def generate(self, source: str, language: str) -> (str, str):
         with subprocess.Popen(['ffmpeg',
@@ -35,11 +40,6 @@ class VoskTranscriber(Transcriber):
 
             else:
                 raise VoskTranscriptionError(f'Unsupported language: {language}')
-
-
-def set_vosk_log_level(debug: bool) -> None:
-    if not debug:
-        SetLogLevel(-1)
 
 
 def new_recognizer(path: str) -> vosk.KaldiRecognizer:

--- a/subtitles/whisper_transcriber.py
+++ b/subtitles/whisper_transcriber.py
@@ -1,7 +1,7 @@
 from transcriber import Transcriber
 import whisper
 
-SRT_TIMESTAMP_FORMAT = "%02d:%02d:%06.3f"
+TIMESTAMP_FORMAT = "%02d:%02d:%06.3f"
 
 
 class WhisperTranscriber(Transcriber):
@@ -38,8 +38,8 @@ def _whisper_to_vtt(segments) -> str:
 
     for i, s in enumerate(segments):
         time_start, time_end = s['start'], s['end']
-        timestamp_start = SRT_TIMESTAMP_FORMAT % _get_hms(time_start)
-        timestamp_end = SRT_TIMESTAMP_FORMAT % _get_hms(time_end)
+        timestamp_start = TIMESTAMP_FORMAT % _get_hms(time_start)
+        timestamp_end = TIMESTAMP_FORMAT % _get_hms(time_end)
 
         vtt.append(f'{i + 1}')
         vtt.append(f'{timestamp_start} --> {timestamp_end}')

--- a/subtitles/whisper_transcriber.py
+++ b/subtitles/whisper_transcriber.py
@@ -42,21 +42,5 @@ def _whisper_to_vtt(segments) -> str:
     return '\n'.join(vtt)
 
 
-def _whisper_to_srt(segments) -> str:
-    """Return SRT subtitle string"""
-    srt = []
-
-    for i, s in enumerate(segments):
-        time_start, time_end = s['start'], s['end']
-        timestamp_start = (SRT_TIMESTAMP_FORMAT % _get_hms(time_start)).replace('.', ',')
-        timestamp_end = (SRT_TIMESTAMP_FORMAT % _get_hms(time_end)).replace('.', ',')
-
-        srt.append(f'{i + 1}')
-        srt.append(f'{timestamp_start} --> {timestamp_end}')
-        srt.append(s['text'].strip() + "\n")
-
-    return '\n'.join(srt)
-
-
 def _get_hms(time: float) -> (float, float, float):
     return int(time / 3600), (time / 60) % 60, time % 60

--- a/subtitles/whisper_transcriber.py
+++ b/subtitles/whisper_transcriber.py
@@ -27,10 +27,10 @@ class WhisperTranscriber(Transcriber):
         try:
             mutex_whisper.acquire()
             result = self.__model.transcribe(source, **options, verbose=False)
-            language = result['language']
-            return _whisper_to_vtt(result['segments']), language
         finally:
             mutex_whisper.release()
+        language = result['language']
+        return _whisper_to_vtt(result['segments']), language
 
 
 def _whisper_to_vtt(segments) -> str:


### PR DESCRIPTION
## Description 
For a complete graceful shutdown the application has to wait until all threads are finished: not only the request, but also the generator threads. An easy solution to this problem is using the built-in Python module `ThreadPoolExecutor` which provides a method `shutdown(wait=True)` that waits for the end of the execution of all threads in a given thread pool.