### PR TITLE
`Feature` Add queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ VOSK_MODEL_DIR=/data
 VOSK_DWNLD_URLS=https://alphacephei.com/vosk/models/vosk-model-small-en-us-0.15.zip,https://alphacephei.com/vosk/models/vosk-model-small-de-0.15.zip
 VOSK_MODELS=model-fr:fr,model-en:en
 WHISPER_MODEL=medium
-MAX_WORKERS=10
+MAX_THREADS=10
+CNT_WORKERS=3
 ```
 </p>
 </details>
@@ -115,7 +116,8 @@ vosk:
       lang: 'de'
 whisper:
   model: 'tiny'
-max_workers: 10
+max_threads: 12
+cnt_workers: 3
 ```
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Microservice that generates subtitles for [TUM-Live](https://live.rbg.tum.de).
 ```bash
 $ grpcurl -plaintext localhost:50055 list live.voice.v1.SubtitleGenerator
 
-voice.SubtitleGenerator.Generate
+live.voice.v1.SubtitleGenerator.Generate
 ```
 
 ```bash

--- a/config.yml
+++ b/config.yml
@@ -16,4 +16,5 @@ vosk:
       lang: 'de'
 whisper:
   model: 'tiny'
-max_workers: 12
+max_threads: 12
+cnt_workers: 3

--- a/subtitles/client.py
+++ b/subtitles/client.py
@@ -1,0 +1,17 @@
+"""Implements gRPC Client facade"""
+
+import logging
+import grpc
+import subtitles_pb2_grpc, subtitles_pb2
+from grpc._channel import _InactiveRpcError
+
+
+def receive(receiver: str, req: subtitles_pb2.ReceiveRequest):
+    with grpc.insecure_channel(receiver) as channel:
+        stub = subtitles_pb2_grpc.SubtitleReceiverStub(channel)
+        try:
+            stub.Receive(req)
+        except _InactiveRpcError as grpc_err:
+            logging.error(grpc_err.details())
+        except Exception as err:
+            logging.error(err)

--- a/subtitles/generator.py
+++ b/subtitles/generator.py
@@ -1,0 +1,53 @@
+import logging
+import queue
+
+import subtitles_pb2, subtitles_pb2_grpc
+import grpc
+from grpc._channel import _InactiveRpcError
+from concurrent.futures import ThreadPoolExecutor
+from transcriber import Transcriber
+from tasks import GenerationTask, StopTask
+
+
+class Generator:
+    """Thread for subtitle generation"""
+
+    def __init__(self,
+                 transcriber: Transcriber,
+                 receiver: str,
+                 executor: ThreadPoolExecutor,
+                 taskqueue: queue.Queue):
+        """Start the generator threads."""
+        executor.submit(run, transcriber, receiver, taskqueue)
+
+
+def run(transcriber: Transcriber, receiver: str, taskqueue: queue.Queue):
+    while True:
+        logging.info('worker: waiting for task...')
+        task = taskqueue.get()
+        if isinstance(task, GenerationTask):
+            logging.info('worker: starting to generate subtitles...')
+            logging.debug(f'worker: task: {task}')
+            generate(transcriber, receiver, task)
+        elif isinstance(task, StopTask):
+            break
+
+
+def generate(transcriber: Transcriber, receiver: str, task: GenerationTask) -> None:
+    subtitles, language = transcriber.generate(task.source, task.language)
+
+    logging.info(f'worker: trying to connect to receiver @ {receiver}')
+    with grpc.insecure_channel(receiver) as channel:
+        stub = subtitles_pb2_grpc.SubtitleReceiverStub(channel)
+        request = subtitles_pb2.ReceiveRequest(
+            stream_id=task.stream_id,
+            subtitles=subtitles,
+            language=language)
+
+        try:
+            stub.Receive(request)
+            logging.info('worker: subtitle-request sent')
+        except _InactiveRpcError as grpc_err:
+            logging.error(grpc_err.details())
+        except Exception as err:
+            logging.error(err)

--- a/subtitles/properties.py
+++ b/subtitles/properties.py
@@ -13,7 +13,8 @@ DEFAULT_PROPERTIES = {
         'models': []
     },
     'whisper': {'model': 'tiny'},
-    'max_workers': None,
+    'max_threads': None,
+    'cnt_workers': 1,
 }
 
 
@@ -90,9 +91,13 @@ class EnvProperties:
 
         properties['whisper']['model'] = os.getenv('WHISPER_MODEL', properties['whisper']['model'])
 
-        max_workers = os.getenv('MAX_WORKERS', properties['max_workers'])
-        if max_workers:
-            properties['max_workers'] = int(max_workers)
+        max_threads = os.getenv('MAX_THREADS', properties['max_threads'])
+        if max_threads:
+            properties['max_threads'] = int(max_threads)
+
+        cnt_workers = os.getenv('CNT_WORKERS', properties['cnt_workers'])
+        if cnt_workers:
+            properties['cnt_workers'] = int(cnt_workers)
 
         return properties
 

--- a/subtitles/properties.py
+++ b/subtitles/properties.py
@@ -3,6 +3,19 @@ from dotenv import load_dotenv
 import os.path
 import yaml
 
+DEFAULT_PROPERTIES = {
+    'api': {'port': 50055},
+    'receiver': {'host': 'localhost', 'port': '50053'},
+    'transcriber': 'whisper',
+    'vosk': {
+        'model_dir': '/tmp',
+        'download_urls': [],
+        'models': []
+    },
+    'whisper': {'model': 'tiny'},
+    'max_workers': None,
+}
+
 
 class PropertyError(Exception):
     pass

--- a/subtitles/subtitles.py
+++ b/subtitles/subtitles.py
@@ -139,14 +139,14 @@ def main():
     transcriber = get_transcriber(properties, debug)
     receiver = f'{properties["receiver"]["host"]}:{properties["receiver"]["port"]}'
     port = properties['api']['port']
-    max_workers = properties['max_workers']
-    task_executor_cnt = 3
+    max_threads = properties['max_threads']
+    cnt_workers = properties['cnt_workers']
 
     logging.debug(properties)
 
-    q = TaskQueue(task_executor_cnt)
-    with ThreadPoolExecutor(max_workers) as executor:
-        [Worker(transcriber, receiver, executor, q) for _ in range(task_executor_cnt)]
+    q = TaskQueue(cnt_workers)
+    with ThreadPoolExecutor(max_threads) as executor:
+        [Worker(transcriber, receiver, executor, q) for _ in range(cnt_workers)]
         serve(executor, q, port, debug)
 
 

--- a/subtitles/subtitles.py
+++ b/subtitles/subtitles.py
@@ -4,7 +4,7 @@ import logging
 import os
 from signal import signal, SIGTERM, SIGINT, SIGQUIT, strsignal
 from concurrent.futures import ThreadPoolExecutor
-from properties import YAMLPropertiesFile, EnvProperties, PropertyError
+from properties import YAMLPropertiesFile, EnvProperties, PropertyError, DEFAULT_PROPERTIES
 from grpc_reflection.v1alpha import reflection
 from google.protobuf import empty_pb2
 from model_loader import download_models, ModelLoadError
@@ -114,18 +114,7 @@ def main():
     debug = os.getenv('DEBUG', '') != ""
     logging.basicConfig(level=(logging.INFO, logging.DEBUG)[debug])
 
-    properties = {
-        'api': {'port': 50055},
-        'receiver': {'host': 'localhost', 'port': '50053'},
-        'transcriber': 'whisper',
-        'vosk': {
-            'model_dir': '/tmp',
-            'download_urls': [],
-            'models': []
-        },
-        'whisper': {'model': 'tiny'},
-        'max_workers': None,
-    }
+    properties = DEFAULT_PROPERTIES
 
     try:
         config_file = os.getenv("CONFIG_FILE")

--- a/subtitles/taskqueue.py
+++ b/subtitles/taskqueue.py
@@ -1,0 +1,13 @@
+import queue
+
+from tasks import StopTask
+
+
+class TaskQueue(queue.Queue):
+    def __init__(self, task_worker_cnt: int = 1):
+        super().__init__()
+        self.task_worker_cnt = task_worker_cnt
+
+    def stop(self):
+        for _ in range(self.task_worker_cnt):
+            self.put(StopTask())

--- a/subtitles/tasks.py
+++ b/subtitles/tasks.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class GenerationTask:
+    source: str
+    language: str
+    stream_id: str
+
+
+class StopTask:
+    pass


### PR DESCRIPTION
### Description 

In order to circumvent any problems regarding RAM usage (e.g. `OutOfMemory`) this PR implements a `TaskQueue` and
a `Worker` class. 

### How it works:
1) Setup queue
2) Spawn `n=CNT_WORKERS` worker threads. 
3) Serve gRPC service
4) gRPC generate requests put `GenerationTask`'s into the queue
5) One worker gets the task and generates subtitles accordingly and sends them to the receiver

### Further Information 
* For the basis of the queue I used Python's [`queue.Queue`](https://docs.python.org/3/library/queue.html).
* For graceful shutdown the shutdown handler communicates with the workers via the shared queue
    * Each worker receive a `StopTask` task and stops executing once all existing `GenerationTask`'s have been handled