### PR TITLE
feat(gRPC): Allow configuring an auth token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 .idea
+
+.DS_STORE

--- a/cmd/voice-service/main.go
+++ b/cmd/voice-service/main.go
@@ -25,6 +25,8 @@ var (
 	hwAccel     = flag.Bool("hw-accel", true, "Enable hardware acceleration")
 	queueSize   = flag.Int("queue-size", 10, "Size of the job queue")
 	target      = flag.String("target", "localhost:50053", "gocast server to push subtitles to")
+	authToken   = flag.String("auth-token", "", "if configured, the token is required as grpc metadata field 'auth' for incoming requests "+
+		"and attached to gRPC metadata for outgoing requests.")
 )
 
 func run() error {
@@ -33,5 +35,5 @@ func run() error {
 	ctx := context.Background()
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	return voiceservice.New(*parallelism, *queueSize, *hwAccel, *target).Run(ctx)
+	return voiceservice.New(*parallelism, *queueSize, *hwAccel, *target, *authToken).Run(ctx)
 }


### PR DESCRIPTION
Tested locally like this:

```bash
go run cmd/voice-service/main.go -auth-token abc &

✗ grpcurl -plaintext \
  -d '{"language": "en", "stream_id":1, "source":"https://example.com"}' \
  -import-path ./protobufs -proto subtitles.proto \
  localhost:50051 live.voice.v1.SubtitleGenerator.Generate
ERROR:
  Code: Unauthenticated
  Message: auth token is not provided
```